### PR TITLE
Fixed methods for getting todays results

### DIFF
--- a/src/Traits/PageViews.php
+++ b/src/Traits/PageViews.php
@@ -13,7 +13,7 @@ trait PageViews
     private function pageViewsToday(): array
     {
         $analyticsData = app(Analytics::class)
-            ->fetchTotalVisitorsAndPageViews(Period::days(1));
+            ->fetchTotalVisitorsAndPageViews(Period::days(0));
 
         return [
             'result' => $analyticsData->last()['pageViews'] ?? 0,

--- a/src/Traits/Sessions.php
+++ b/src/Traits/Sessions.php
@@ -11,7 +11,7 @@ trait Sessions
 
     private function sessionsToday(): array
     {
-        $results = $this->performQuery('ga:sessions', 'ga:date', Period::days(1));
+        $results = $this->performQuery('ga:sessions', 'ga:date', Period::days(0));
 
         return [
             'previous' => $results->first()['value'] ?? 0,

--- a/src/Traits/SessionsDuration.php
+++ b/src/Traits/SessionsDuration.php
@@ -11,7 +11,7 @@ trait SessionsDuration
 
     private function sessionDurationToday(): array
     {
-        $results = $this->performQuery('ga:avgSessionDuration', 'ga:date', Period::days(1));
+        $results = $this->performQuery('ga:avgSessionDuration', 'ga:date', Period::days(0));
 
         return [
             'previous' => $results->first()['value'] ?? 0,

--- a/src/Traits/Visitors.php
+++ b/src/Traits/Visitors.php
@@ -13,7 +13,7 @@ trait Visitors
     private function visitorsToday(): array
     {
         $analyticsData = app(Analytics::class)
-            ->fetchTotalVisitorsAndPageViews(Period::days(1));
+            ->fetchTotalVisitorsAndPageViews(Period::days(0));
 
         return [
             'result' => $analyticsData->last()['visitors'] ?? 0,


### PR DESCRIPTION
Per a spatie issue https://github.com/spatie/laravel-analytics/issues/361#issuecomment-630431898, you can see that when retrieving todays results, the period set should be 0, not 1.