### PR TITLE
Fixes for new setup of GA4

### DIFF
--- a/src/Traits/Visitors.php
+++ b/src/Traits/Visitors.php
@@ -15,7 +15,7 @@ trait Visitors
         $analyticsData = Analytics::fetchTotalVisitorsAndPageViews(Period::days(1));
 
         return [
-            'result' => $analyticsData[0]['activeUsers'],
+            'result' => $analyticsData[0]['activeUsers'] ?? 0,
             'previous' => $analyticsData[1]['activeUsers'] ?? 0,
         ];
     }
@@ -25,8 +25,8 @@ trait Visitors
         $analyticsData = Analytics::fetchTotalVisitorsAndPageViews(Period::create(Carbon::yesterday()->clone()->subDay(), Carbon::yesterday()));
 
         return [
-            'result' => $analyticsData[0]['activeUsers'],
-            'previous' => $analyticsData[1]['activeUsers'],
+            'result' => $analyticsData[0]['activeUsers'] ?? 0,
+            'previous' => $analyticsData[1]['activeUsers'] ?? 0,
         ];
     }
 


### PR DESCRIPTION
Analytics::fetchTotalVisitorsAndPageViews(Period::days(1)) returns empty result and hence the application crashes if the condition is not checked.