### PR TITLE
Fix New Setup GA4

### DIFF
--- a/src/Traits/Visitors.php
+++ b/src/Traits/Visitors.php
@@ -15,8 +15,8 @@ trait Visitors
         $analyticsData = Analytics::fetchTotalVisitorsAndPageViews(Period::days(1));
 
         return [
-            'result' => $analyticsData[0]['activeUsers'],
-            'previous' => $analyticsData[1]['activeUsers'],
+            'result' => $analyticsData[0]['activeUsers'] ?? 0,
+            'previous' => $analyticsData[1]['activeUsers'] ?? 0,
         ];
     }
 
@@ -25,8 +25,8 @@ trait Visitors
         $analyticsData = Analytics::fetchTotalVisitorsAndPageViews(Period::create(Carbon::yesterday()->clone()->subDay(), Carbon::yesterday()));
 
         return [
-            'result' => $analyticsData[0]['activeUsers'],
-            'previous' => $analyticsData[1]['activeUsers'],
+            'result' => $analyticsData[0]['activeUsers'] ?? 0,
+            'previous' => $analyticsData[1]['activeUsers'] ?? 0,
         ];
     }
 


### PR DESCRIPTION
The data is empty and hence it crashes unless this check is done.