### PR TITLE
explicitly convert from float to int

### DIFF
--- a/src/FilamentGoogleAnalytics.php
+++ b/src/FilamentGoogleAnalytics.php
@@ -39,7 +39,7 @@ class FilamentGoogleAnalytics
             return 0;
         }
 
-        return (($this->value - $this->previous) / $this->previous) * 100;
+        return (int) (($this->value - $this->previous) / $this->previous) * 100;
     }
 
     public function trajectoryValue()


### PR DESCRIPTION
The `compute` function in the `FilamentGoogleAnalytics` class (https://github.com/bezhanSalleh/filament-google-analytics/blob/44030360e379f8b0d73eb313d545566b3112bd67/src/FilamentGoogleAnalytics.php#L36C25-L36C25) is typed to return an int. However, the variables used in the function result in a float being returned (and implicitly converted to an int as a result). This can result in excessive error logging about the implicit conversion of a float to an int (as it loses precision). To resolve this, the function can be updated to explicitly convert the result to an int.