### PR TITLE
allow widgets to be used in multiple pages

### DIFF
--- a/src/Traits/CanViewWidget.php
+++ b/src/Traits/CanViewWidget.php
@@ -13,7 +13,7 @@ trait CanViewWidget
 
         $globalStatus = config('filament-google-analytics.' . Str::of(static::class)->after('Widgets\\')->before('Widget')->snake() . '.global');
 
-        if ($filamentDashboardStatus && request()->routeIs($filamentPagesRoutePrefix . 'dashboard')) {
+        if ($filamentDashboardStatus) {
             return true;
         }
 


### PR DESCRIPTION
It would be useful to use the widgets in the package in multiple Filament pages. Or, to be able to use them in pages not called "Dashboard" (for example, users may want to use them in a separate "Analytics" page).

However, the `CanViewWidget` Trait (https://github.com/bezhanSalleh/filament-google-analytics/blob/44030360e379f8b0d73eb313d545566b3112bd67/src/Traits/CanViewWidget.php#L16) is currently setup to only allow the widgets to be used in the built-in dashboard or in a Filament page title "Dashboard". This Pull Request updates the Trait to allow the widgets to be used in other Filament pages as well.