### PR TITLE
[fix] Session & Session Duration for today/yesterday

### DIFF
--- a/src/FilamentGoogleAnalytics.php
+++ b/src/FilamentGoogleAnalytics.php
@@ -6,25 +6,25 @@ use Illuminate\Support\Carbon;
 
 class FilamentGoogleAnalytics
 {
-    public string $previous;
+    public int|float $previous = 0;
 
     public string $format;
 
-    public function __construct(public ?string $value = null) {}
+    public function __construct(public int|float $value = 0) {}
 
-    public static function for(?string $value = null)
+    public static function for(int|float $value = 0): static
     {
         return new static($value);
     }
 
-    public function previous(string $previous)
+    public function previous(int|float $previous): static
     {
         $this->previous = $previous;
 
         return $this;
     }
 
-    public function format(string $format)
+    public function format(string $format): static
     {
         $this->format = $format;
 
@@ -33,11 +33,12 @@ class FilamentGoogleAnalytics
 
     public function compute(): int
     {
-        if ($this->value == 0 || $this->previous == 0 || $this->previous == null) {
-            return 0;
-        }
-
-        return intval((($this->value - $this->previous) / $this->previous) * 100);
+        return match (true) {
+            $this->value == 0 && $this->previous == 0 => 0,
+            $this->value > 0 && $this->previous == 0 => $this->value,
+            $this->previous != 0 => intval((($this->value - $this->previous) / $this->previous) * 100),
+            default => 0,
+        };
     }
 
     public function trajectoryValue()

--- a/src/FilamentGoogleAnalytics.php
+++ b/src/FilamentGoogleAnalytics.php
@@ -6,18 +6,18 @@ use Illuminate\Support\Carbon;
 
 class FilamentGoogleAnalytics
 {
-    public int|float $previous = 0;
+    public int | float $previous = 0;
 
     public string $format;
 
-    public function __construct(public int|float $value = 0) {}
+    public function __construct(public int | float $value = 0) {}
 
-    public static function for(int|float $value = 0): static
+    public static function for(int | float $value = 0): static
     {
         return new static($value);
     }
 
-    public function previous(int|float $previous): static
+    public function previous(int | float $previous): static
     {
         $this->previous = $previous;
 

--- a/src/Traits/MetricDiff.php
+++ b/src/Traits/MetricDiff.php
@@ -3,9 +3,10 @@
 namespace BezhanSalleh\FilamentGoogleAnalytics\Traits;
 
 use Carbon\Carbon;
+use Spatie\Analytics\Period;
+use Spatie\Analytics\OrderBy;
 use Illuminate\Support\Collection;
 use Spatie\Analytics\Facades\Analytics;
-use Spatie\Analytics\Period;
 
 trait MetricDiff
 {
@@ -15,6 +16,9 @@ trait MetricDiff
             $period,
             [$metric],
             [$dimensions],
+            orderBy: [
+                OrderBy::dimension($dimensions, true),
+            ],
         );
 
         $results = $analyticsData;

--- a/src/Traits/MetricDiff.php
+++ b/src/Traits/MetricDiff.php
@@ -3,10 +3,10 @@
 namespace BezhanSalleh\FilamentGoogleAnalytics\Traits;
 
 use Carbon\Carbon;
-use Spatie\Analytics\Period;
-use Spatie\Analytics\OrderBy;
 use Illuminate\Support\Collection;
 use Spatie\Analytics\Facades\Analytics;
+use Spatie\Analytics\OrderBy;
+use Spatie\Analytics\Period;
 
 trait MetricDiff
 {

--- a/src/Traits/Sessions.php
+++ b/src/Traits/Sessions.php
@@ -13,7 +13,7 @@ trait Sessions
     {
         $results = $this->get('sessions', 'date', Period::days(1));
 
-        return match(true) {
+        return match (true) {
             ($results->containsOneItem() && ($results->first()['date'])->isYesterday()) => [
                 'previous' => $results->first()['value'],
                 'result' => 0,

--- a/src/Traits/Sessions.php
+++ b/src/Traits/Sessions.php
@@ -13,10 +13,24 @@ trait Sessions
     {
         $results = $this->get('sessions', 'date', Period::days(1));
 
-        return [
-            'previous' => $results->first()['value'] ?? 0,
-            'result' => $results->last()['value'] ?? 0,
-        ];
+        return match(true) {
+            ($results->containsOneItem() && ($results->first()['date'])->isYesterday()) => [
+                'previous' => $results->first()['value'],
+                'result' => 0,
+            ],
+            ($results->containsOneItem() && ($results->first()['date'])->isToday()) => [
+                'previous' => 0,
+                'result' => $results->first()['value'],
+            ],
+            $results->isEmpty() => [
+                'previous' => 0,
+                'result' => 0,
+            ],
+            default => [
+                'previous' => $results->last()['value'] ?? 0,
+                'result' => $results->first()['value'] ?? 0,
+            ]
+        };
     }
 
     private function sessionsYesterday(): array
@@ -24,8 +38,8 @@ trait Sessions
         $results = $this->get('sessions', 'date', Period::create(Carbon::yesterday()->clone()->subDay(), Carbon::yesterday()));
 
         return [
-            'previous' => $results->first()['value'] ?? 0,
-            'result' => $results->last()['value'] ?? 0,
+            'previous' => $results->last()['value'] ?? 0,
+            'result' => $results->first()['value'] ?? 0,
         ];
     }
 

--- a/src/Traits/SessionsDuration.php
+++ b/src/Traits/SessionsDuration.php
@@ -13,7 +13,7 @@ trait SessionsDuration
     {
         $results = $this->get('averageSessionDuration', 'date', Period::days(1));
 
-        return match(true) {
+        return match (true) {
             ($results->containsOneItem() && ($results->first()['date'])->isYesterday()) => [
                 'previous' => $results->first()['value'],
                 'result' => 0,

--- a/src/Traits/SessionsDuration.php
+++ b/src/Traits/SessionsDuration.php
@@ -13,10 +13,24 @@ trait SessionsDuration
     {
         $results = $this->get('averageSessionDuration', 'date', Period::days(1));
 
-        return [
-            'previous' => $results->last()['value'] ?? 0,
-            'result' => $results->first()['value'] ?? 0,
-        ];
+        return match(true) {
+            ($results->containsOneItem() && ($results->first()['date'])->isYesterday()) => [
+                'previous' => $results->first()['value'],
+                'result' => 0,
+            ],
+            ($results->containsOneItem() && ($results->first()['date'])->isToday()) => [
+                'previous' => 0,
+                'result' => $results->first()['value'],
+            ],
+            $results->isEmpty() => [
+                'previous' => 0,
+                'result' => 0,
+            ],
+            default => [
+                'previous' => $results->last()['value'] ?? 0,
+                'result' => $results->first()['value'] ?? 0,
+            ]
+        };
     }
 
     private function sessionDurationYesterday(): array
@@ -24,8 +38,8 @@ trait SessionsDuration
         $results = $this->get('averageSessionDuration', 'date', Period::create(Carbon::yesterday()->clone()->subDay(), Carbon::yesterday()));
 
         return [
-            'previous' => $results->first()['value'] ?? 0,
-            'result' => $results->last()['value'] ?? 0,
+            'previous' => $results->last()['value'] ?? 0,
+            'result' => $results->first()['value'] ?? 0,
         ];
     }
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of metric calculations and data retrieval, focusing on type consistency and better handling of edge cases. The most important changes include updating type hints and default values, refining the computation logic, and enhancing data retrieval methods.

### Type Consistency and Default Values:

* [`src/FilamentGoogleAnalytics.php`](diffhunk://#diff-b651eb358f20c7d9daa135be835ced776ba91290f185255aa7ee219324804ac8L9-R27): Updated type hints for the `previous` and `value` properties and their respective methods to use `int|float` instead of `string`, and set default values to `0`.

### Computation Logic:

* [`src/FilamentGoogleAnalytics.php`](diffhunk://#diff-b651eb358f20c7d9daa135be835ced776ba91290f185255aa7ee219324804ac8L36-R41): Refined the `compute` method to use a `match` expression for better readability and handling of different conditions.

### Data Retrieval Enhancements:

* [`src/Traits/MetricDiff.php`](diffhunk://#diff-38103286e94e6b939b559ab3b49228b1a099a836679f63ba6a098b320ece76a3R19-R21): Added `OrderBy` to the `get` method to sort results by dimensions.
* [`src/Traits/Sessions.php`](diffhunk://#diff-cbea9819dc6faae242a32878e00d66a9c55af187219b376c17f164a5dab93bc0L16-R42): Enhanced the `sessionsToday` method to handle different scenarios using a `match` expression for improved clarity.
* [`src/Traits/SessionsDuration.php`](diffhunk://#diff-d7bdb15f038d895df209ee0eea4404df9ae0d187c7a1b5e37aee8c021a34b0b3L16-R42): Improved the `sessionDurationToday` method with a `match` expression to better handle edge cases.

### Dependency Management:

* [`src/Traits/MetricDiff.php`](diffhunk://#diff-38103286e94e6b939b559ab3b49228b1a099a836679f63ba6a098b320ece76a3R6-L8): Added the `OrderBy` import to support the new sorting functionality in data retrieval.