### PR TITLE
patched metric-diff

### DIFF
--- a/src/FilamentGoogleAnalytics.php
+++ b/src/FilamentGoogleAnalytics.php
@@ -10,7 +10,9 @@ class FilamentGoogleAnalytics
 
     public string $format;
 
-    public function __construct(public int | float $value = 0) {}
+    public function __construct(public int | float $value = 0)
+    {
+    }
 
     public static function for(int | float $value = 0): static
     {

--- a/src/FilamentGoogleAnalytics.php
+++ b/src/FilamentGoogleAnalytics.php
@@ -6,27 +6,25 @@ use Illuminate\Support\Carbon;
 
 class FilamentGoogleAnalytics
 {
-    public string $previous;
+    public int | float $previous = 0;
 
     public string $format;
 
-    public function __construct(public ?string $value = null)
-    {
-    }
+    public function __construct(public int | float $value = 0) {}
 
-    public static function for(?string $value = null)
+    public static function for(int | float $value = 0): static
     {
         return new static($value);
     }
 
-    public function previous(string $previous)
+    public function previous(int | float $previous): static
     {
         $this->previous = $previous;
 
         return $this;
     }
 
-    public function format(string $format)
+    public function format(string $format): static
     {
         $this->format = $format;
 
@@ -35,11 +33,12 @@ class FilamentGoogleAnalytics
 
     public function compute(): int
     {
-        if ($this->value == 0 || $this->previous == 0 || $this->previous == null) {
-            return 0;
-        }
-
-        return (($this->value - $this->previous) / $this->previous) * 100;
+        return match (true) {
+            $this->value == 0 && $this->previous == 0 => 0,
+            $this->value > 0 && $this->previous == 0 => $this->value,
+            $this->previous != 0 => intval((($this->value - $this->previous) / $this->previous) * 100),
+            default => 0,
+        };
     }
 
     public function trajectoryValue()
@@ -86,7 +85,7 @@ class FilamentGoogleAnalytics
      */
     public function trajectoryDescription(): string
     {
-        return static::thousandsFormater(abs($this->compute())).$this->format.' '.$this->trajectoryLabel();
+        return static::thousandsFormater(abs($this->compute())) . $this->format . ' ' . $this->trajectoryLabel();
     }
 
     public static function thousandsFormater($value)
@@ -100,7 +99,7 @@ class FilamentGoogleAnalytics
             $x_parts = ['k', 'm', 'b', 't'];
             $x_count_parts = count($x_array) - 1;
             $x_display = $x;
-            $x_display = $x_array[0].((int) $x_array[1][0] !== 0 ? '.'.$x_array[1][0] : '');
+            $x_display = $x_array[0] . ((int) $x_array[1][0] !== 0 ? '.' . $x_array[1][0] : '');
             $x_display .= $x_parts[$x_count_parts - 1];
 
             return $x_display;

--- a/src/Traits/MetricDiff.php
+++ b/src/Traits/MetricDiff.php
@@ -5,6 +5,7 @@ namespace BezhanSalleh\FilamentGoogleAnalytics\Traits;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Spatie\Analytics\Facades\Analytics;
+use Spatie\Analytics\OrderBy;
 use Spatie\Analytics\Period;
 
 trait MetricDiff
@@ -15,6 +16,9 @@ trait MetricDiff
             $period,
             [$metric],
             [$dimensions],
+            orderBy: [
+                OrderBy::dimension($dimensions, true),
+            ],
         );
 
         $results = $analyticsData;

--- a/src/Traits/Sessions.php
+++ b/src/Traits/Sessions.php
@@ -13,10 +13,24 @@ trait Sessions
     {
         $results = $this->get('sessions', 'date', Period::days(1));
 
-        return [
-            'previous' => $results->first()['value'] ?? 0,
-            'result' => $results->last()['value'] ?? 0,
-        ];
+        return match (true) {
+            ($results->containsOneItem() && ($results->first()['date'])->isYesterday()) => [
+                'previous' => $results->first()['value'],
+                'result' => 0,
+            ],
+            ($results->containsOneItem() && ($results->first()['date'])->isToday()) => [
+                'previous' => 0,
+                'result' => $results->first()['value'],
+            ],
+            $results->isEmpty() => [
+                'previous' => 0,
+                'result' => 0,
+            ],
+            default => [
+                'previous' => $results->last()['value'] ?? 0,
+                'result' => $results->first()['value'] ?? 0,
+            ]
+        };
     }
 
     private function sessionsYesterday(): array
@@ -24,8 +38,8 @@ trait Sessions
         $results = $this->get('sessions', 'date', Period::create(Carbon::yesterday()->clone()->subDay(), Carbon::yesterday()));
 
         return [
-            'previous' => $results->first()['value'] ?? 0,
-            'result' => $results->last()['value'] ?? 0,
+            'previous' => $results->last()['value'] ?? 0,
+            'result' => $results->first()['value'] ?? 0,
         ];
     }
 

--- a/src/Traits/SessionsDuration.php
+++ b/src/Traits/SessionsDuration.php
@@ -13,10 +13,24 @@ trait SessionsDuration
     {
         $results = $this->get('averageSessionDuration', 'date', Period::days(1));
 
-        return [
-            'previous' => $results->last()['value'] ?? 0,
-            'result' => $results->first()['value'] ?? 0,
-        ];
+        return match (true) {
+            ($results->containsOneItem() && ($results->first()['date'])->isYesterday()) => [
+                'previous' => $results->first()['value'],
+                'result' => 0,
+            ],
+            ($results->containsOneItem() && ($results->first()['date'])->isToday()) => [
+                'previous' => 0,
+                'result' => $results->first()['value'],
+            ],
+            $results->isEmpty() => [
+                'previous' => 0,
+                'result' => 0,
+            ],
+            default => [
+                'previous' => $results->last()['value'] ?? 0,
+                'result' => $results->first()['value'] ?? 0,
+            ]
+        };
     }
 
     private function sessionDurationYesterday(): array
@@ -24,8 +38,8 @@ trait SessionsDuration
         $results = $this->get('averageSessionDuration', 'date', Period::create(Carbon::yesterday()->clone()->subDay(), Carbon::yesterday()));
 
         return [
-            'previous' => $results->first()['value'] ?? 0,
-            'result' => $results->last()['value'] ?? 0,
+            'previous' => $results->last()['value'] ?? 0,
+            'result' => $results->first()['value'] ?? 0,
         ];
     }
 


### PR DESCRIPTION
This pull request includes several changes to improve type safety, refactor methods, and enhance data retrieval ordering in the `FilamentGoogleAnalytics` class and related traits.

### Type Safety and Refactoring:

* [`src/FilamentGoogleAnalytics.php`](diffhunk://#diff-b651eb358f20c7d9daa135be835ced776ba91290f185255aa7ee219324804ac8L9-R27): Updated the `previous` and `value` properties to accept `int` or `float` types and provided default values. Refactored methods to use these types.
* [`src/FilamentGoogleAnalytics.php`](diffhunk://#diff-b651eb358f20c7d9daa135be835ced776ba91290f185255aa7ee219324804ac8L38-R41): Refactored the `compute` method to use a `match` expression for cleaner and more readable logic.

### Data Retrieval and Ordering:

* [`src/Traits/MetricDiff.php`](diffhunk://#diff-38103286e94e6b939b559ab3b49228b1a099a836679f63ba6a098b320ece76a3R8): Added `OrderBy` to the imports and updated the `get` method to include ordering by dimensions. [[1]](diffhunk://#diff-38103286e94e6b939b559ab3b49228b1a099a836679f63ba6a098b320ece76a3R8) [[2]](diffhunk://#diff-38103286e94e6b939b559ab3b49228b1a099a836679f63ba6a098b320ece76a3R19-R21)

### Session Data Handling:

* [`src/Traits/Sessions.php`](diffhunk://#diff-cbea9819dc6faae242a32878e00d66a9c55af187219b376c17f164a5dab93bc0L16-R42): Refactored the `sessionsToday` method to use a `match` expression for better handling of different scenarios.
* [`src/Traits/SessionsDuration.php`](diffhunk://#diff-d7bdb15f038d895df209ee0eea4404df9ae0d187c7a1b5e37aee8c021a34b0b3L16-R42): Refactored the `sessionDurationToday` method to use a `match` expression for better handling of different scenarios.